### PR TITLE
Undo/redo

### DIFF
--- a/crates/bevy_command_central_egui/src/lib.rs
+++ b/crates/bevy_command_central_egui/src/lib.rs
@@ -12,10 +12,7 @@ use epaint::{
 };
 use bevy_command_central_plugin::*;
 use claydash_data::{ClaydashData, ClaydashValue};
-use observable_key_value_tree::{
-    ObservableKVTree,
-    SimpleUpdateTracker
-};
+use observable_key_value_tree::ObservableKVTree;
 
 #[derive(Resource)]
 pub struct CommandCentralUiState {
@@ -57,7 +54,7 @@ fn command_search(
     ctx: egui::Context,
     mut claydash_ui_state: ResMut<CommandCentralUiState>,
     command_central_state: ResMut<CommandCentralState>,
-    tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>,
+    tree: &mut ObservableKVTree<ClaydashValue>,
 ) {
     let rounding: Rounding = Rounding::same(5.0);
     let widget_offset = egui::vec2(10.0, 20.0);
@@ -114,7 +111,7 @@ fn command_results_ui(
     ui: &mut egui::Ui,
     mut claydash_ui_state: ResMut<CommandCentralUiState>,
     mut bevy_command_central: ResMut<CommandCentralState>,
-    tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>
+    tree: &mut ObservableKVTree<ClaydashValue>
 ) {
     let rounding = Rounding::same(5.0);
     let command_search_str: &mut String = &mut claydash_ui_state.command_search_str;

--- a/crates/claydash_data/src/lib.rs
+++ b/crates/claydash_data/src/lib.rs
@@ -4,7 +4,9 @@ use sdf_consts::*;
 
 use observable_key_value_tree::{
     ObservableKVTree,
-    CanBeNone, Update,
+    CanBeNone,
+    Update,
+    Snapshot
 };
 
 use bevy_sdf_object::*;
@@ -36,8 +38,12 @@ pub enum ClaydashValue {
     Fn(fn(&mut ObservableKVTree<ClaydashValue>)),
     #[serde(skip)]
     VecUpdate(Vec<Update<ClaydashValue>>),
+    #[serde(skip)]
+    VecSnapshot(Vec<Snapshot<ClaydashValue>>),
     EditorState(EditorState),
     Bool(bool),
+    #[serde(skip)]
+    Snapshot(Snapshot<ClaydashValue>),
     None,
 }
 
@@ -203,6 +209,13 @@ impl ClaydashValue {
         unwrap_vec_update_or,
         VecUpdate,
         Vec<Update<ClaydashValue>>
+    );
+
+    define_unwrap_methods_for_vec!(
+        unwrap_vec_snapshot,
+        unwrap_vec_snapshot_or,
+        VecSnapshot,
+        Vec<Snapshot<ClaydashValue>>
     );
 
     pub fn is_none(&self) -> bool {

--- a/crates/claydash_data/src/lib.rs
+++ b/crates/claydash_data/src/lib.rs
@@ -4,7 +4,7 @@ use sdf_consts::*;
 
 use observable_key_value_tree::{
     ObservableKVTree,
-    CanBeNone,
+    CanBeNone, Update,
 };
 
 use bevy_sdf_object::*;
@@ -23,6 +23,7 @@ pub enum EditorState {
 #[derive(Clone, Serialize, Deserialize)]
 pub enum ClaydashValue {
     VecUuid(Vec<uuid::Uuid>),
+    VecI32(Vec<i32>),
     I32(i32),
     F32(f32),
     Vec2(Vec2),
@@ -33,6 +34,8 @@ pub enum ClaydashValue {
     VecSDFObject(Vec<SDFObject>),
     #[serde(skip)]
     Fn(fn(&mut ObservableKVTree<ClaydashValue>)),
+    #[serde(skip)]
+    VecUpdate(Vec<Update<ClaydashValue>>),
     EditorState(EditorState),
     Bool(bool),
     None,
@@ -193,6 +196,13 @@ impl ClaydashValue {
         unwrap_vec_sdf_object_or,
         VecSDFObject,
         Vec<SDFObject>
+    );
+
+    define_unwrap_methods_for_vec!(
+        unwrap_vec_update,
+        unwrap_vec_update_or,
+        VecUpdate,
+        Vec<Update<ClaydashValue>>
     );
 
     pub fn is_none(&self) -> bool {

--- a/crates/claydash_data/src/lib.rs
+++ b/crates/claydash_data/src/lib.rs
@@ -218,6 +218,13 @@ impl ClaydashValue {
         Vec<Snapshot<ClaydashValue>>
     );
 
+    define_unwrap_methods_for_vec!(
+        unwrap_vec_i32,
+        unwrap_vec_i32_or,
+        VecI32,
+        Vec<i32>
+    );
+
     pub fn is_none(&self) -> bool {
         match &self {
             Self::None => true,

--- a/crates/claydash_data/src/lib.rs
+++ b/crates/claydash_data/src/lib.rs
@@ -4,7 +4,7 @@ use sdf_consts::*;
 
 use observable_key_value_tree::{
     ObservableKVTree,
-    SimpleUpdateTracker, CanBeNone,
+    CanBeNone,
 };
 
 use bevy_sdf_object::*;
@@ -32,7 +32,7 @@ pub enum ClaydashValue {
     Transform(Transform),
     VecSDFObject(Vec<SDFObject>),
     #[serde(skip)]
-    Fn(fn(&mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>)),
+    Fn(fn(&mut ObservableKVTree<ClaydashValue>)),
     EditorState(EditorState),
     Bool(bool),
     None,
@@ -161,7 +161,7 @@ impl ClaydashValue {
         unwrap_fn_or_default,
         unwrap_fn_or,
         Fn,
-        fn(&mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>),
+        fn(&mut ObservableKVTree<ClaydashValue>),
         panic!("No Fn value stored.")
     );
 
@@ -205,7 +205,7 @@ impl ClaydashValue {
 
 #[derive(Resource, Default)]
 pub struct ClaydashData {
-    pub tree: ObservableKVTree<ClaydashValue, SimpleUpdateTracker>
+    pub tree: ObservableKVTree<ClaydashValue>
 }
 
 pub struct ClaydashDataPlugin;

--- a/crates/observable_key_value_tree/src/lib.rs
+++ b/crates/observable_key_value_tree/src/lib.rs
@@ -170,7 +170,9 @@ pub struct ObservableKVTree <ValueType: Default + Clone + CanBeNone<ValueType>>
     pub snapshot_change_accumulator: Snapshot<ValueType>,
     #[serde(skip)]
     pub last_snapshot_version: i32,
+    #[serde(skip)]
     pub versions: Vec<i32>,
+    #[serde(skip)]
     pub current_version_index: Option<i32>,
 }
 
@@ -485,8 +487,6 @@ impl <ValueType: Default + Clone + CanBeNone<ValueType>> ObservableKVTree<ValueT
 
         let len = self.versions.len();
         self.current_version_index = Some(len as i32 - 1);
-
-        self.dump_undo_state();
     }
 
     pub fn undo(&mut self) {
@@ -509,8 +509,6 @@ impl <ValueType: Default + Clone + CanBeNone<ValueType>> ObservableKVTree<ValueT
         self.go_to_snapshot_with_version(version);
 
         self.current_version_index = Some(current_version_index);
-
-        self.dump_undo_state();
     }
 
     pub fn redo(&mut self) {
@@ -534,8 +532,6 @@ impl <ValueType: Default + Clone + CanBeNone<ValueType>> ObservableKVTree<ValueT
 
         // Make sure we keep same versions array after moving to a snapshot
         self.current_version_index = Some(current_version_index);
-
-        self.dump_undo_state();
     }
 
 
@@ -544,7 +540,7 @@ impl <ValueType: Default + Clone + CanBeNone<ValueType>> ObservableKVTree<ValueT
         let current_version_index = self.current_version_index;
 
         for (index, version) in versions.iter().enumerate() {
-            let arrow =  if index == current_version_index.unwrap_or(-1) as usize { " <-" }  else { ";" };
+            let arrow =  if index == current_version_index.unwrap_or(-1) as usize { " <-" }  else { "" };
             println!("{} {}", version, arrow);
         }
     }

--- a/src/claydash_ui.rs
+++ b/src/claydash_ui.rs
@@ -14,6 +14,8 @@ use bevy_command_central_egui::{CommandCentralUiState, command_ui};
 use rfd::FileHandle;
 use std::sync::mpsc::{channel, Sender, Receiver};
 
+use crate::undo_redo::{UNDO_SHORTCUT, REDO_SHORTCUT};
+
 pub struct ClaydashUIPlugin;
 
 impl Plugin for ClaydashUIPlugin {
@@ -134,6 +136,25 @@ fn claydash_ui(
                             _ = tx.send(UiMessage::OpenFileHandle(file.unwrap()));
                         });
                         _task.detach();
+                    }
+                });
+                ui.menu_button("Edit", |ui| {
+                    if ui
+                        .add(
+                            egui::Button::new("Undo")
+                                .shortcut_text(UNDO_SHORTCUT),
+                        )
+                        .clicked() {
+                        tree.undo();
+                    }
+
+                    if ui
+                        .add(
+                            egui::Button::new("Redo")
+                                .shortcut_text(REDO_SHORTCUT),
+                        )
+                        .clicked() {
+                        tree.redo();
                     }
                 });
             });

--- a/src/claydash_ui.rs
+++ b/src/claydash_ui.rs
@@ -20,11 +20,11 @@ impl Plugin for ClaydashUIPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(EguiPlugin)
             .init_resource::<CommandCentralUiState>()
+            .add_systems(Startup, (setup_messages, color_picker_ui))
             .add_systems(Update, (
                 claydash_ui,
                 handle_tasks
-            ))
-            .add_systems(Startup, (setup_messages, color_picker_ui));
+            ));
     }
 }
 

--- a/src/claydash_ui.rs
+++ b/src/claydash_ui.rs
@@ -9,7 +9,7 @@ use egui::containers::Frame;
 use egui::Color32;
 use epaint::{Stroke, Pos2};
 use claydash_data::{ClaydashValue, ClaydashData};
-use observable_key_value_tree::{ObservableKVTree, SimpleUpdateTracker};
+use observable_key_value_tree::{ObservableKVTree};
 use bevy_command_central_egui::{CommandCentralUiState, command_ui};
 use rfd::FileHandle;
 use std::sync::mpsc::{channel, Sender, Receiver};
@@ -77,7 +77,7 @@ fn handle_tasks(
         },
         Ok(UiMessage::VecU8(data)) => {
             let tree = &mut data_resource.as_mut().tree;
-            let scene: Result<ObservableKVTree<ClaydashValue, SimpleUpdateTracker>, serde_json::Error> = serde_json::from_slice(&data);
+            let scene: Result<ObservableKVTree<ClaydashValue>, serde_json::Error> = serde_json::from_slice(&data);
             match scene {
                 Ok(scene) => {
                     tree.set_tree("scene", scene);
@@ -215,7 +215,7 @@ fn draw_color_picker(
     pointer_position: Pos2,
     asset_server: Res<AssetServer>,
     assets: Res<Assets<Image>>,
-    tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>
+    tree: &mut ObservableKVTree<ClaydashValue>
 ) {
     let distance_from_wheel_center =
         ((pointer_position.x - CIRCLE_CENTER_X).powi(2) +

--- a/src/interactions.rs
+++ b/src/interactions.rs
@@ -251,7 +251,7 @@ pub fn on_mouse_down(
         _ => {
             // Exit grab/scale on click
             tree.set_path("editor.state", ClaydashValue::EditorState(Start));
-            crate::undo_redo::make_undo_redo_snapshot(tree);
+            tree.make_undo_redo_snapshot();
             return;
         }
     }

--- a/src/interactions/interaction_commands_and_shortcuts.rs
+++ b/src/interactions/interaction_commands_and_shortcuts.rs
@@ -1,6 +1,6 @@
 use bevy::{
     prelude::*,
-    input::keyboard::KeyCode
+    input::keyboard::KeyCode, ecs::system::SystemState
 };
 use claydash_data::{ClaydashValue, ClaydashData};
 use bevy_command_central_plugin::CommandCentralState;
@@ -155,11 +155,21 @@ fn set_objects_initial_properties(
 }
 
 pub fn run_shortcut_commands(
-    mut bevy_command_central: ResMut<CommandCentralState>,
-    mut data_resource: ResMut<ClaydashData>,
-    windows: Query<&Window>,
-    keys: Res<Input<KeyCode>>
+    world: &mut World,
 ){
+    let mut system_state: SystemState<(
+        ResMut<CommandCentralState>,
+        ResMut<ClaydashData>,
+        Query<&Window>,
+        Res<Input<KeyCode>>
+    )> = SystemState::new(world);
+
+    let (mut bevy_command_central,
+         mut data_resource,
+         windows,
+         keys) = system_state.get_mut(world);
+
+
     let commands = &mut bevy_command_central.commands.commands;
     let tree = &mut data_resource.as_mut().tree;
     let mut shortcut_sequence: String = String::new();

--- a/src/interactions/interaction_commands_and_shortcuts.rs
+++ b/src/interactions/interaction_commands_and_shortcuts.rs
@@ -6,7 +6,7 @@ use claydash_data::{ClaydashValue, ClaydashData};
 use bevy_command_central_plugin::CommandCentralState;
 use observable_key_value_tree::{
     ObservableKVTree,
-    SimpleUpdateTracker
+    UpdateTracker
 };
 use bevy_sdf_object::SDFObject;
 use command_central::CommandBuilder;
@@ -118,7 +118,7 @@ pub fn register_interaction_commands(mut bevy_command_central: ResMut<CommandCen
 }
 
 fn set_objects_initial_properties(
-    tree: &mut  ObservableKVTree<ClaydashValue, SimpleUpdateTracker>
+    tree: &mut  ObservableKVTree<ClaydashValue>
 ) {
     let mut objects: Vec<SDFObject> = match tree.get_path("scene.sdf_objects") {
         ClaydashValue::VecSDFObject(data) => data,
@@ -251,49 +251,49 @@ fn key_to_name(key: &KeyCode) -> String {
 }
 
 
-fn reset_constraints(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn reset_constraints(tree: &mut ObservableKVTree<ClaydashValue>) {
     tree.set_path("editor.constrain_x", ClaydashValue::Bool(false));
     tree.set_path("editor.constrain_y", ClaydashValue::Bool(false));
     tree.set_path("editor.constrain_z", ClaydashValue::Bool(false));
 }
 
-fn start_grab(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn start_grab(tree: &mut ObservableKVTree<ClaydashValue>) {
     reset_constraints(tree);
     set_objects_initial_properties(tree);
     tree.set_path("editor.state", ClaydashValue::EditorState(Grabbing));
 }
 
-fn toggle_path(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>, path: String) {
+fn toggle_path(tree: &mut ObservableKVTree<ClaydashValue>, path: String) {
     let current_value = tree.get_path("editor.constrain_x").unwrap_bool_or(false);
     tree.set_path(&path, ClaydashValue::Bool(!current_value));
 }
 
-fn constrain_x(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn constrain_x(tree: &mut ObservableKVTree<ClaydashValue>) {
     toggle_path(tree, "editor.constrain_x".to_string());
 }
 
-fn constrain_y(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn constrain_y(tree: &mut ObservableKVTree<ClaydashValue>) {
     toggle_path(tree, "editor.constrain_y".to_string());
 }
 
-fn constrain_z(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn constrain_z(tree: &mut ObservableKVTree<ClaydashValue>) {
     toggle_path(tree, "editor.constrain_z".to_string());
 }
 
-fn start_scale(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn start_scale(tree: &mut ObservableKVTree<ClaydashValue>) {
     reset_constraints(tree);
     set_objects_initial_properties(tree);
     tree.set_path("editor.state", ClaydashValue::EditorState(Scaling));
 }
 
-fn start_rotate(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn start_rotate(tree: &mut ObservableKVTree<ClaydashValue>) {
     reset_constraints(tree);
     set_objects_initial_properties(tree);
     tree.set_path("editor.state", ClaydashValue::EditorState(Rotating));
 }
 
 /// Cancel edit and bring back transforms to original value.
-fn escape(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn escape(tree: &mut ObservableKVTree<ClaydashValue>) {
     let state = tree.get_path("editor.state").unwrap_editor_state_or(Start);
 
     match state {
@@ -324,11 +324,11 @@ fn escape(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
     tree.set_path("scene.sdf_objects", ClaydashValue::VecSDFObject(sdf_objects));
 }
 
-fn finish(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn finish(tree: &mut ObservableKVTree<ClaydashValue>) {
     tree.set_path("editor.state", ClaydashValue::EditorState(Start));
 }
 
-fn duplicate(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn duplicate(tree: &mut ObservableKVTree<ClaydashValue>) {
     // Find selected objects
     let selected_object_uuids = tree.get_path("scene.selected_uuids").unwrap_vec_uuid_or(Vec::new());
 
@@ -357,7 +357,7 @@ fn duplicate(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
     start_grab(tree);
 }
 
-fn select_all_or_none(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn select_all_or_none(tree: &mut ObservableKVTree<ClaydashValue>) {
     let selected_uuids = tree.get_path("scene.selected_uuids").unwrap_vec_uuid_or(Vec::new());
     let sdf_objects = tree.get_path("scene.sdf_objects").unwrap_vec_sdf_object_or(Vec::new());
 
@@ -375,7 +375,7 @@ fn select_all_or_none(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTra
     }
 }
 
-fn delete(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn delete(tree: &mut ObservableKVTree<ClaydashValue>) {
     // Find selected objects
     let selected_object_uuids = tree.get_path("scene.selected_uuids").unwrap_vec_uuid_or(Vec::new());
 
@@ -391,7 +391,7 @@ fn delete(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
     tree.set_path("scene.sdf_objects", ClaydashValue::VecSDFObject(filtered_objects));
 }
 
-fn spawn_sphere(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn spawn_sphere(tree: &mut ObservableKVTree<ClaydashValue>) {
     let color = match tree.get_path("editor.colorpicker.color") {
         ClaydashValue::Vec4(data) => data,
         _ => Vec4::new(0.4, 0.2, 0.0, 1.0),
@@ -421,7 +421,7 @@ fn spawn_sphere(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>)
     start_grab(tree);
 }
 
-fn spawn_box(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+fn spawn_box(tree: &mut ObservableKVTree<ClaydashValue>) {
     let color = match tree.get_path("editor.colorpicker.color") {
         ClaydashValue::Vec4(data) => data,
         _ => Vec4::new(0.4, 0.2, 0.0, 1.0),

--- a/src/interactions/interaction_commands_and_shortcuts.rs
+++ b/src/interactions/interaction_commands_and_shortcuts.rs
@@ -6,7 +6,6 @@ use claydash_data::{ClaydashValue, ClaydashData};
 use bevy_command_central_plugin::CommandCentralState;
 use observable_key_value_tree::{
     ObservableKVTree,
-    UpdateTracker
 };
 use bevy_sdf_object::SDFObject;
 use command_central::CommandBuilder;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use bevy::{
 use bevy_sdf_object::*;
 use bevy_mod_picking::prelude::*;
 
+use undo_redo::ClaydashUndoRedoPlugin;
 #[allow(unused_imports)]
 use wasm_bindgen::prelude::*;
 
@@ -32,6 +33,7 @@ use claydash_data::{ClaydashDataPlugin, ClaydashValue, ClaydashData};
 
 mod interactions;
 mod claydash_ui;
+mod undo_redo;
 
 fn main() {
     App::new()
@@ -53,7 +55,8 @@ fn main() {
             BevySDFObjectPlugin,
             claydash_ui::ClaydashUIPlugin,
             ClaydashInteractionPlugin,
-            MaterialPlugin::<GridMaterial>::default()
+            MaterialPlugin::<GridMaterial>::default(),
+            ClaydashUndoRedoPlugin
         ))
         .add_systems(Startup, (remove_picking_logs,
                                setup_frame_limit,

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use bevy::{
 use bevy_sdf_object::*;
 use bevy_mod_picking::prelude::*;
 
-use undo_redo::ClaydashUndoRedoPlugin;
+use undo_redo::{ClaydashUndoRedoPlugin, make_undo_redo_snapshot};
 #[allow(unused_imports)]
 use wasm_bindgen::prelude::*;
 
@@ -77,6 +77,9 @@ pub fn default_duck(mut data_resource: ResMut<ClaydashData>) {
     let tree = &mut data_resource.as_mut().tree;
     let scene: Result<ObservableKVTree<ClaydashValue>, serde_json::Error> = serde_json::from_str(duck::DEFAULT_DUCK);
     tree.set_tree("scene", scene.unwrap());
+
+    // Add snapshot for initial state
+    make_undo_redo_snapshot(tree);
 }
 
 pub fn register_debug_commands(mut bevy_command_central: ResMut<CommandCentralState>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 #[allow(unused_imports)]
 use std::fs::read_to_string;
 use command_central::CommandBuilder;
-use observable_key_value_tree::{ObservableKVTree, SimpleUpdateTracker};
+use observable_key_value_tree::{ObservableKVTree};
 use smooth_bevy_cameras::{
     LookTransformPlugin,
     controllers::orbit::{
@@ -72,7 +72,7 @@ mod duck;
 
 pub fn default_duck(mut data_resource: ResMut<ClaydashData>) {
     let tree = &mut data_resource.as_mut().tree;
-    let scene: Result<ObservableKVTree<ClaydashValue, SimpleUpdateTracker>, serde_json::Error> = serde_json::from_str(duck::DEFAULT_DUCK);
+    let scene: Result<ObservableKVTree<ClaydashValue>, serde_json::Error> = serde_json::from_str(duck::DEFAULT_DUCK);
     tree.set_tree("scene", scene.unwrap());
 }
 
@@ -87,7 +87,7 @@ pub fn register_debug_commands(mut bevy_command_central: ResMut<CommandCentralSt
 
 }
 
-pub fn dump_tree(tree: &mut ObservableKVTree<ClaydashValue, SimpleUpdateTracker>) {
+pub fn dump_tree(tree: &mut ObservableKVTree<ClaydashValue>) {
     let serialized = serde_json::to_string_pretty(&tree).unwrap();
     println!("{}", serialized);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use bevy::{
 use bevy_sdf_object::*;
 use bevy_mod_picking::prelude::*;
 
-use undo_redo::{ClaydashUndoRedoPlugin, make_undo_redo_snapshot};
+use undo_redo::ClaydashUndoRedoPlugin;
 #[allow(unused_imports)]
 use wasm_bindgen::prelude::*;
 
@@ -79,7 +79,7 @@ pub fn default_duck(mut data_resource: ResMut<ClaydashData>) {
     tree.set_tree("scene", scene.unwrap());
 
     // Add snapshot for initial state
-    make_undo_redo_snapshot(tree);
+    tree.make_undo_redo_snapshot();
 }
 
 pub fn register_debug_commands(mut bevy_command_central: ResMut<CommandCentralState>) {

--- a/src/undo_redo.rs
+++ b/src/undo_redo.rs
@@ -13,6 +13,9 @@ impl Plugin for ClaydashUndoRedoPlugin {
     }
 }
 
+pub const UNDO_SHORTCUT: &str = "Shift+Z";
+pub const REDO_SHORTCUT: &str = "Shift+Y";
+
 fn setup_undo_redo_commands(mut bevy_command_central: ResMut<CommandCentralState>) {
     let commands = &mut bevy_command_central.commands;
 
@@ -20,7 +23,7 @@ fn setup_undo_redo_commands(mut bevy_command_central: ResMut<CommandCentralState
         .title("Undo")
         .system_name("undo")
         .docs("Undo last action.")
-        .shortcut("Shift+Z")
+        .shortcut(&UNDO_SHORTCUT)
         .insert_param("callback", "system callback", Some(ClaydashValue::Fn(undo)))
         .write(commands);
 
@@ -28,7 +31,7 @@ fn setup_undo_redo_commands(mut bevy_command_central: ResMut<CommandCentralState
         .title("Redo")
         .system_name("redo")
         .docs("Redo last action.")
-        .shortcut("Shift+Y")
+        .shortcut(&REDO_SHORTCUT)
         .insert_param("callback", "system callback", Some(ClaydashValue::Fn(redo)))
         .write(commands);
 }

--- a/src/undo_redo.rs
+++ b/src/undo_redo.rs
@@ -36,95 +36,13 @@ fn setup_undo_redo_commands(mut bevy_command_central: ResMut<CommandCentralState
 fn undo(
     tree: &mut ObservableKVTree<ClaydashValue>
 ) {
-    let versions = tree.get_path("editor.versions").unwrap_vec_i32_or(vec!());
-    let mut current_version_index = tree.get_path("editor.current_version_index").unwrap_i32_or(0);
-
-    if current_version_index == 0 {
-        // nothing to undo
-        return;
-    }
-
-    if versions.len() == 0 {
-        // nothing to undo
-        return;
-    }
-
-    current_version_index -= 1;
-
-    let version = versions[current_version_index as usize];
-
-    tree.go_to_snapshot_with_version(version);
-
-    // Make sure we keep same versions array after moving to a snapshot
-    tree.set_path_without_notifying("editor.versions", ClaydashValue::VecI32(versions));
-    tree.set_path_without_notifying("editor.current_version_index", ClaydashValue::I32(current_version_index));
-
-
-    dump_undo_state(tree);
+    tree.undo();
+    tree.dump_undo_state();
 }
 
 fn redo(
     tree: &mut ObservableKVTree<ClaydashValue>
 ) {
-    let versions = tree.get_path("editor.versions").unwrap_vec_i32_or(vec!());
-    let mut current_version_index = tree.get_path("editor.current_version_index").unwrap_i32_or(0);
-
-    if current_version_index == versions.len() as i32 - 1 {
-        // nothing to redo
-        return;
-    }
-
-    if versions.len() == 0 {
-        // nothing to redo
-        return;
-    }
-
-    current_version_index += 1;
-
-    let version = versions[current_version_index as usize];
-
-    tree.go_to_snapshot_with_version(version);
-
-    // Make sure we keep same versions array after moving to a snapshot
-    tree.set_path_without_notifying("editor.versions", ClaydashValue::VecI32(versions));
-    tree.set_path_without_notifying("editor.current_version_index", ClaydashValue::I32(current_version_index));
-
-    dump_undo_state(tree);
-}
-
-pub fn dump_undo_state(tree: &mut ObservableKVTree<ClaydashValue>) {
-    let versions = tree.get_path("editor.versions").unwrap_vec_i32_or(vec!());
-    let current_version_index = tree.get_path("editor.current_version_index").unwrap_i32_or(0);
-
-    for (index, version) in versions.iter().enumerate() {
-        let arrow =  if index == current_version_index as usize  { " <-" }  else { "" };
-        println!("{} {}", version, arrow);
-    }
-}
-
-pub fn make_undo_redo_snapshot(tree: &mut ObservableKVTree<ClaydashValue>) {
-    let previous_versions = tree.get_path("editor.versions");
-    let version = tree.make_snapshot();
-
-    let versions: Vec<i32> = match previous_versions {
-        ClaydashValue::VecI32(versions) => { versions },
-        _ => {
-            vec!(version)
-        }
-    };
-
-    // Slice, since after an action, we can't redo.
-    let current_version_index = tree.get_path("editor.current_version_index").unwrap_i32_or(versions.len() as i32 - 1);
-
-    let mut new_versions = versions[0..(current_version_index as usize + 1)].to_vec();
-
-    new_versions.push(version);
-
-    tree.set_path_without_notifying("editor.versions", ClaydashValue::VecI32(
-        new_versions.clone()
-    ));
-
-    tree.set_path_without_notifying("editor.current_version_index", ClaydashValue::I32(new_versions.len() as i32 - 1));
-
-    dump_undo_state(tree);
+    tree.redo();
+    tree.dump_undo_state();
 }

--- a/src/undo_redo.rs
+++ b/src/undo_redo.rs
@@ -23,30 +23,55 @@ fn setup_undo_redo_commands(mut bevy_command_central: ResMut<CommandCentralState
         .shortcut("Shift+Z")
         .insert_param("callback", "system callback", Some(ClaydashValue::Fn(undo)))
         .write(commands);
+
+    CommandBuilder::new()
+        .title("Redo")
+        .system_name("redo")
+        .docs("Redo last action.")
+        .shortcut("Shift+Y")
+        .insert_param("callback", "system callback", Some(ClaydashValue::Fn(redo)))
+        .write(commands);
 }
 
 fn undo(
     tree: &mut ObservableKVTree<ClaydashValue>
 ) {
-    let previous_operations = tree.get_path("scene.operation");
-
-    match previous_operations {
+    let operations = tree.get_path("scene.operations");
+    // This is a number where:
+    //  - 0 = we are at the last edit
+    //  - -1 = we just did undo
+    //  - -2 = we did 2 undos
+    let mut undo_redo_pointer = tree.get_path("scene.undo_pointer").unwrap_i32_or(0);
+    match operations {
         ClaydashValue::VecI32(versions) => {
-            match versions.last() {
-                Some(last) => {
-                    tree.revert_snapshot(*last);
-                    let versions = &versions[0..versions.len()-1];
-                    tree.set_path_without_notifying("scene.operation", ClaydashValue::VecI32(versions.to_owned()));
-                },
-                _ => {}
-            }
+            undo_redo_pointer -= 1;
+            let end = versions.len() as i32 - 1;
+            tree.revert_snapshot_version(end - undo_redo_pointer);
+            tree.set_path("scene.undo_pointer", ClaydashValue::I32(undo_redo_pointer));
+        }
+        _ => { }
+    }
+}
+
+fn redo(
+    tree: &mut ObservableKVTree<ClaydashValue>
+) {
+    let mut undo_redo_pointer = tree.get_path("scene.undo_pointer").unwrap_i32_or(0);
+    let operations = tree.get_path("scene.operations");
+
+    match operations {
+        ClaydashValue::VecI32(versions) => {
+            undo_redo_pointer -= 1;
+            let end = versions.len() as i32 - 1;
+            tree.revert_snapshot_version(end - undo_redo_pointer);
+            tree.set_path("scene.undo_pointer", ClaydashValue::I32(undo_redo_pointer));
         }
         _ => { }
     }
 }
 
 pub fn make_undo_redo_snapshot(tree: &mut ObservableKVTree<ClaydashValue>) {
-    let previous_operations = tree.get_path("scene.operation");
+    let previous_operations = tree.get_path("scene.operations");
     let version = tree.make_snapshot();
 
     let versions: Vec<i32> = match previous_operations {
@@ -60,5 +85,5 @@ pub fn make_undo_redo_snapshot(tree: &mut ObservableKVTree<ClaydashValue>) {
         }
     };
 
-    tree.set_path_without_notifying("scene.operation", ClaydashValue::VecI32(versions));
+    tree.set_path_without_notifying("scene.operations", ClaydashValue::VecI32(versions));
 }

--- a/src/undo_redo.rs
+++ b/src/undo_redo.rs
@@ -1,0 +1,64 @@
+use bevy::prelude::*;
+use claydash_data::{ClaydashData, ClaydashValue};
+use observable_key_value_tree::ObservableKVTree;
+use command_central::CommandBuilder;
+use bevy_command_central_plugin::CommandCentralState;
+
+pub struct ClaydashUndoRedoPlugin;
+
+impl Plugin for ClaydashUndoRedoPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ClaydashData>()
+            .add_systems(Startup, setup_undo_redo_commands);
+    }
+}
+
+fn setup_undo_redo_commands(mut bevy_command_central: ResMut<CommandCentralState>) {
+    let commands = &mut bevy_command_central.commands;
+
+    CommandBuilder::new()
+        .title("Undo")
+        .system_name("undo")
+        .docs("Undo last action.")
+        .shortcut("Shift+Z")
+        .insert_param("callback", "system callback", Some(ClaydashValue::Fn(undo)))
+        .write(commands);
+}
+
+fn undo(
+    tree: &mut ObservableKVTree<ClaydashValue>
+) {
+    let previous_operations = tree.get_path("scene.operation");
+
+    match previous_operations {
+        ClaydashValue::VecI32(versions) => {
+            match versions.last() {
+                Some(last) => {
+                    tree.revert_snapshot(*last);
+                    let versions = &versions[0..versions.len()-1];
+                    tree.set_path_without_notifying("scene.operation", ClaydashValue::VecI32(versions.to_owned()));
+                },
+                _ => {}
+            }
+        }
+        _ => { }
+    }
+}
+
+pub fn make_undo_redo_snapshot(tree: &mut ObservableKVTree<ClaydashValue>) {
+    let previous_operations = tree.get_path("scene.operation");
+    let version = tree.make_snapshot();
+
+    let versions: Vec<i32> = match previous_operations {
+        ClaydashValue::VecI32(versions) => {
+            let mut versions: Vec<i32> = versions.clone();
+            versions.push(version);
+            versions
+        },
+        _ => {
+            vec!(version)
+        }
+    };
+
+    tree.set_path_without_notifying("scene.operation", ClaydashValue::VecI32(versions));
+}


### PR DESCRIPTION
This PR adds undo/redo to the tree (observable_key_value_tree) and starts using it in claydash.


Summary:

This PR makes several changes across multiple Rust modules, primarily focusing on the `ObservableKVTree` structure and its usage.

### Key Changes:

1. **Refactor of `ObservableKVTree`:**
   - Removed `SimpleUpdateTracker` dependency, simplifying the `ObservableKVTree` by using a single generic parameter instead of two.
   - Added snapshot functionality for undo/redo operations.
   - Added methods to manage snapshots (`make_snapshot`, `revert_snapshot_version`, etc.).
   - Implemented a channel-based update notification system.
   - Added methods for undo/redo operations (`undo`, `redo`, `make_undo_redo_snapshot`).

3. **Adaptation of Code in Other Modules:**
   - Updated the usage of `ObservableKVTree` throughout the other modules (`bevy_command_central_egui`, `claydash_ui`, `interactions`, etc.) to align with the refactored `ObservableKVTree`.
   - Integrated undo/redo functionality in UI interactions.
   - Adjustments to function signatures and calls to match the updated `ObservableKVTree` structure.
